### PR TITLE
Improved compatibility with different Telnet configurations

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -169,16 +169,28 @@ namespace TryKeys
                 return;
             }
 
-            s_username = config["username"].Length > 0 ? config["username"] : "root";
-            s_password = config["password"].Length > 0 ? config["password"] : "eevblog";
+            s_username = config["username"];
+            s_password = config["password"];
+            if (s_username.Length == 0)
+                Console.WriteLine("WARNING: Trying to login with blank username! If this is not desired, please specify the username (using key \"username\") in TryKeys.json.");
+            if (s_password.Length == 0)
+                Console.WriteLine("WARNING: Trying to login with blank password! If this is not desired, please specify the password (using key \"password\") in TryKeys.json.");
 
             Console.WriteLine("Execution starts @ " + DateTime.Now.ToShortDateString() + " " + DateTime.Now.ToShortTimeString());
 
-            client = new TelnetClient(s_ip, 23);
+            client = new TelnetClient(s_ip, i_port);
             if (!client.Login(s_username, s_password))
             {
-                Console.WriteLine("ERROR: Unable to establish telnet connection on port 23 to scope.");
-                return;
+                Console.WriteLine("ERROR: Unable to login to the scope via telnet using port " + i_port + ".");
+                Console.WriteLine("Do you want to try to continue without authentication? [y/N]");
+                while (true) {
+                    var c = Console.ReadKey();
+                    Console.Write("\b \b");
+                    if (c.KeyChar == 'n' || c.KeyChar == 'N' || c.Key == ConsoleKey.Enter)
+                        return;
+                    else if (c.KeyChar == 'y' || c.KeyChar == 'Y')
+                        break;
+                }
             }
 
             foreach (String option in new String[] { "AWG", "MSO", "WIFI" })

--- a/TryKeys.json
+++ b/TryKeys.json
@@ -1,7 +1,7 @@
 {
   "keyfile": "g:trykeys.txt",
   "scopeip": "192.168.10.14",
-  "port": 23,
+  "port": "23",
   "username": "root",
   "password": "eevblog",
   "bandwidth": "true",


### PR DESCRIPTION
- The port specified in TryKeys.json is actually used now
- The port specified in TryKeys.json must be a string, so changed the default to reflect the requirement
- Added support for unauthenticated Telnet connections
- Added support for empty username and/or password - a warning is shown instead of an error

The purpose of this change is to enable compatibility with the unauthenticated Telnet server launched via the `telnetd -l/bin/sh -p9999` shell command (using `SHELLCMD` in SCPI or [plurn's firmware modification](https://www.eevblog.com/forum/testgear/sds1104x-e-hack-to-200mhz-and-full-options/msg2478699/#msg2478699) on firmware versions newer than 6.1.26).
